### PR TITLE
正文页、评论页初始化策略修改

### DIFF
--- a/app/src/main/java/org/chaos/fx/cnbeta/details/CommentContract.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/details/CommentContract.java
@@ -53,10 +53,14 @@ interface CommentContract {
 
         void hideProgress();
 
-        void notifyItemChanged(Comment c);
+        void notifyCommentChanged(Comment c);
     }
 
     interface Presenter extends BasePresenter<View> {
+        void setSN(String sn);
+
+        void loadComments();
+
         void refreshComments(int page);
 
         void against(Comment c);
@@ -69,6 +73,8 @@ interface CommentContract {
 
         void publishComment(String content, String captcha, int pid);
 
-        void updateToken(String token);
+        boolean isCommentEnable();
+
+        String getToken();
     }
 }

--- a/app/src/main/java/org/chaos/fx/cnbeta/details/CommentDialog.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/details/CommentDialog.java
@@ -53,8 +53,14 @@ import io.reactivex.schedulers.Schedulers;
 
 public class CommentDialog extends DialogFragment {
 
-    public static CommentDialog newInstance() {
-        return new CommentDialog();
+    private static final String KEY_TOKEN = "token";
+
+    public static CommentDialog newInstance(String token) {
+        Bundle args = new Bundle();
+        args.putString(KEY_TOKEN, token);
+        CommentDialog fragment = new CommentDialog();
+        fragment.setArguments(args);
+        return fragment;
     }
 
     @BindView(R.id.captcha) ImageView mCaptchaView;
@@ -118,7 +124,7 @@ public class CommentDialog extends DialogFragment {
     }
 
     private void flashCaptcha() {
-        mCaptchaDisposable = CnBetaApiHelper.getCaptchaDataUrl(((ContentActivity) getActivity()).getToken())
+        mCaptchaDisposable = CnBetaApiHelper.getCaptchaDataUrl(getArguments().getString(KEY_TOKEN))
                 .subscribeOn(Schedulers.io())
                 .map(new Function<WebCaptcha, String>() {
                     @Override

--- a/app/src/main/java/org/chaos/fx/cnbeta/details/ContentContract.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/details/ContentContract.java
@@ -18,7 +18,6 @@ package org.chaos.fx.cnbeta.details;
 
 import org.chaos.fx.cnbeta.BasePresenter;
 import org.chaos.fx.cnbeta.BaseView;
-import org.chaos.fx.cnbeta.net.model.WebCommentResult;
 
 /**
  * @author Chaos
@@ -32,18 +31,12 @@ interface ContentContract {
 
         void showLoadingError(boolean show);
 
-        void setupChildViews();
+        void setupDetailsFragment(String html);
 
-        void showTransition();
+        void setupCommentFragment(String sn);
     }
 
     interface Presenter extends BasePresenter<View> {
         void loadArticleHtml();
-
-        String getArticleToken();
-
-        String getHtmlBody();
-
-        WebCommentResult getWebComments();
     }
 }

--- a/app/src/main/java/org/chaos/fx/cnbeta/details/DetailsContract.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/details/DetailsContract.java
@@ -56,5 +56,7 @@ interface DetailsContract {
         String[] getAllImageUrls();
 
         int indexOfImage(String url);
+
+        void loadContentByHtml(String content);
     }
 }

--- a/app/src/main/java/org/chaos/fx/cnbeta/details/DetailsFragment.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/details/DetailsFragment.java
@@ -59,16 +59,14 @@ import butterknife.ButterKnife;
 public class DetailsFragment extends BaseFragment implements DetailsContract.View {
 
     protected static final String KEY_SID = "sid";
+    protected static final String KEY_TITLE = "title";
     protected static final String KEY_TOPIC_LOGO = "topic_logo";
-    protected static final String KEY_HTML_CONTENT = "html_content";
-    protected static final String KEY_COMMENT_COUNT = "comment_count";
 
-    public static DetailsFragment newInstance(int sid, String topicLogoLink, String htmlBody, int commentCount) {
+    public static DetailsFragment newInstance(int sid, String title, String topicLogoLink) {
         Bundle args = new Bundle();
         args.putInt(KEY_SID, sid);
+        args.putString(KEY_TITLE, title);
         args.putString(KEY_TOPIC_LOGO, topicLogoLink);
-        args.putString(KEY_HTML_CONTENT, htmlBody);
-        args.putInt(KEY_COMMENT_COUNT, commentCount);
         DetailsFragment fragment = new DetailsFragment();
         fragment.setArguments(args);
         return fragment;
@@ -119,7 +117,7 @@ public class DetailsFragment extends BaseFragment implements DetailsContract.Vie
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mPresenter = new DetailsPresenter(new Bundle(getArguments()));
+        mPresenter = new DetailsPresenter(getArguments().getInt(KEY_SID), getArguments().getString(KEY_TOPIC_LOGO));
     }
 
     @Override
@@ -132,7 +130,7 @@ public class DetailsFragment extends BaseFragment implements DetailsContract.Vie
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_content, container, false);
+        return inflater.inflate(R.layout.fragment_details, container, false);
     }
 
     @Override
@@ -144,6 +142,9 @@ public class DetailsFragment extends BaseFragment implements DetailsContract.Vie
         getActivity().setExitSharedElementCallback(mSharedElementCallback);// for ImagePagerActivity
 
         mSid = getArguments().getInt(KEY_SID);
+        mTitleView.setText(getArguments().getString(KEY_TITLE));
+
+        getActivity().supportStartPostponedEnterTransition();
 
         mCommentCountView.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -164,7 +165,7 @@ public class DetailsFragment extends BaseFragment implements DetailsContract.Vie
     @Override
     public void onHiddenChanged(boolean hidden) {
         if (!hidden) {
-            setActionBarTitle(R.string.content);
+            setActionBarTitle(R.string.details);
         }
     }
 
@@ -198,10 +199,8 @@ public class DetailsFragment extends BaseFragment implements DetailsContract.Vie
                 ((BitmapDrawable) authorImg.getDrawable()).getBitmap(), toTimeline);
     }
 
-    public void updateCommentCount(int count) {
-        if (mCommentCountView != null && isVisible()) {
-            mCommentCountView.setText(String.format(getString(R.string.content_comment_count), count));
-        }
+    public void handleHtmlContent(String html) {
+        mPresenter.loadContentByHtml(html);
     }
 
     @Override

--- a/app/src/main/java/org/chaos/fx/cnbeta/details/DetailsPresenter.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/details/DetailsPresenter.java
@@ -18,7 +18,6 @@ package org.chaos.fx.cnbeta.details;
 
 import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
-import android.os.Bundle;
 import android.text.TextUtils;
 
 import org.chaos.fx.cnbeta.net.model.NewsContent;
@@ -41,11 +40,6 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 
-import static org.chaos.fx.cnbeta.details.DetailsFragment.KEY_COMMENT_COUNT;
-import static org.chaos.fx.cnbeta.details.DetailsFragment.KEY_HTML_CONTENT;
-import static org.chaos.fx.cnbeta.details.DetailsFragment.KEY_SID;
-import static org.chaos.fx.cnbeta.details.DetailsFragment.KEY_TOPIC_LOGO;
-
 /**
  * @author Chaos
  *         10/26/16
@@ -55,8 +49,6 @@ class DetailsPresenter implements DetailsContract.Presenter {
 
     private int mSid;
     private String mLogoLink;
-    private String mHtmlContent;
-    private int mCommentCount;
 
     private NewsContent mNewsContent;
     private DetailsContract.View mView;
@@ -65,11 +57,9 @@ class DetailsPresenter implements DetailsContract.Presenter {
 
     private List<String> mImageUrls = new ArrayList<>();
 
-    DetailsPresenter(Bundle arguments) {
-        mSid = arguments.getInt(KEY_SID);
-        mLogoLink = arguments.getString(KEY_TOPIC_LOGO);
-        mHtmlContent = arguments.getString(KEY_HTML_CONTENT);
-        mCommentCount = arguments.getInt(KEY_COMMENT_COUNT);
+    DetailsPresenter(int sid, String logo) {
+        mSid = sid;
+        mLogoLink = logo;
     }
 
     @Override
@@ -93,7 +83,6 @@ class DetailsPresenter implements DetailsContract.Presenter {
     @Override
     public void subscribe(DetailsContract.View view) {
         mView = view;
-        loadContent();
     }
 
     @Override
@@ -102,15 +91,14 @@ class DetailsPresenter implements DetailsContract.Presenter {
         mContentDisposable.dispose();
     }
 
-    private void loadContent() {
-        mContentDisposable = Observable.just(mHtmlContent)
+    @Override
+    public void loadContentByHtml(String html) {
+        mContentDisposable = Observable.just(html)
                 .subscribeOn(Schedulers.io())
                 .map(new Function<String, NewsContent>() {
                     @Override
                     public NewsContent apply(String html) {
-                        NewsContent newsContent = parseHtmlContent(html);
-                        newsContent.setCommentCount(mCommentCount);
-                        return newsContent;
+                        return parseHtmlContent(html);
                     }
                 })
                 .observeOn(AndroidSchedulers.mainThread())
@@ -119,7 +107,6 @@ class DetailsPresenter implements DetailsContract.Presenter {
                     public void accept(NewsContent newsContent) {
                         mNewsContent = newsContent;
                         parseNewsContent(newsContent);
-                        mView.showTransition();
                     }
                 });
     }
@@ -170,7 +157,7 @@ class DetailsPresenter implements DetailsContract.Presenter {
         mView.setTitle(newsContent.getTitle());
         mView.setAuthor(newsContent.getAuthor());
         mView.setTimeString(newsContent.getTime());
-        mView.setCommentCount(newsContent.getCommentCount());
+//        mView.setCommentCount(newsContent.getCommentCount()); // WebApi 转换的 NewsContent 的 comment count 永远是 0
 
         mView.setSource(newsContent.getSource());
 

--- a/app/src/main/java/org/chaos/fx/cnbeta/home/ArticlesFragment.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/home/ArticlesFragment.java
@@ -108,7 +108,8 @@ public class ArticlesFragment extends BaseFragment
                         ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(),
                                 Pair.create(v, getString(R.string.transition_details_background)),
                                 Pair.create(tv, getString(R.string.transition_details_title)));
-                ContentActivity.start(getActivity(), summary.getSid(), summary.getTopicLogo(), options);
+                ContentActivity.start(getActivity(), summary.getSid(), summary.getTitle(),
+                        summary.getTopicLogo(), options);
             }
         });
         mArticleAdapter.addFooterView(

--- a/app/src/main/java/org/chaos/fx/cnbeta/hotarticles/Top10Fragment.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/hotarticles/Top10Fragment.java
@@ -83,7 +83,8 @@ public class Top10Fragment extends BaseFragment implements Top10Contract.View,
                         ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(),
                                 Pair.create(v, getString(R.string.transition_details_background)),
                                 Pair.create(tv, getString(R.string.transition_details_title)));
-                ContentActivity.start(getActivity(), summary.getSid(), summary.getTopicLogo(), options);
+                ContentActivity.start(getActivity(), summary.getSid(), summary.getTitle(),
+                        summary.getTopicLogo(), options);
             }
         });
         mTop10View.setAdapter(mTop10Adapter);

--- a/app/src/main/java/org/chaos/fx/cnbeta/hotcomment/HotCommentFragment.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/hotcomment/HotCommentFragment.java
@@ -78,7 +78,7 @@ public class HotCommentFragment extends BaseFragment implements HotCommentContra
                         ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(),
                                 Pair.create(v, getString(R.string.transition_details_background)),
                                 Pair.create(tv, getString(R.string.transition_details_title)));
-                ContentActivity.start(getActivity(), comment.getSid(), null, options);
+                ContentActivity.start(getActivity(), comment.getSid(), comment.getSubject(), null, options);
             }
         });
 

--- a/app/src/main/java/org/chaos/fx/cnbeta/rank/RankSubFragment.java
+++ b/app/src/main/java/org/chaos/fx/cnbeta/rank/RankSubFragment.java
@@ -95,7 +95,8 @@ public class RankSubFragment extends Fragment implements RankSubContract.View, S
                         ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(),
                                 Pair.create(v, getString(R.string.transition_details_background)),
                                 Pair.create(tv, getString(R.string.transition_details_title)));
-                ContentActivity.start(getActivity(), summary.getSid(), summary.getTopicLogo(), options);
+                ContentActivity.start(getActivity(), summary.getSid(), summary.getTitle(),
+                        summary.getTopicLogo(), options);
             }
         });
         mArticlesView.setAdapter(mArticleAdapter);

--- a/app/src/main/res/layout/activity_content.xml
+++ b/app/src/main/res/layout/activity_content.xml
@@ -36,8 +36,16 @@
         layout="@layout/layout_loading"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-    <include
-        layout="@layout/layout_error"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+    <!-- Use a clickable layout to disable swiping with finger in ViewPager-->
+    <FrameLayout
+        android:id="@+id/error_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="true">
+
+        <include
+            layout="@layout/layout_error"
+            android:visibility="visible" />
+    </FrameLayout>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -46,6 +46,7 @@
             android:layout_marginEnd="8dp"
             android:layout_marginRight="8dp"
             android:layout_marginTop="16dp"
+            android:src="@color/author_image"
             tools:background="#000" />
 
         <TextView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -46,4 +46,7 @@
 
     <color name="gallery_action_bar">#7F000000</color>
 
+    <color name="author_image">#FAFAFA</color>
+    <color name="holder_color">#FAFAFA</color>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="nav_help">帮助 &amp; 反馈</string>
     <string name="nav_settings">设置</string>
 
-    <string name="content">文章正文</string>
+    <string name="details">文章正文</string>
     <string name="comment">评论</string>
 
     <string name="content_comment_count">%d 条评论</string>


### PR DESCRIPTION
1. [ContentActivity](https://github.com/ChaosLeong/FxcnBeta/compare/optimize/content-load?expand=1#diff-e966aa2e76789975411118faaceeee06) 负责获取 HTML 以及评论所需的 SN 码，评论初始化逻辑移至 [CommentPresenter](https://github.com/ChaosLeong/FxcnBeta/compare/optimize/content-load?expand=1#diff-7ee2b19dd22d9d02c3f69265a1e10cfa) 中
2. 优化正文页 transition 动画的 start 时机，避免假死